### PR TITLE
Update String+Extensions.swift

### DIFF
--- a/Source/Extensions/String+Extensions.swift
+++ b/Source/Extensions/String+Extensions.swift
@@ -13,7 +13,7 @@ extension String {
     subscript (r: Range<Int>) -> String {
         let start = index(startIndex, offsetBy: r.lowerBound)
         let end = index(startIndex, offsetBy: r.upperBound)
-        return String(self[Range(start ..< end)])
+        return String(self[start ..< end])
     }
     
     var containsAlphabets: Bool {


### PR DESCRIPTION
Fixed error that prevents project from compiling. 
The Range instance is already produced by using the operator on the variables: start and end.